### PR TITLE
Fix Authenticator null check in APIConnector

### DIFF
--- a/SpotifyAPI.Web/Http/APIConnector.cs
+++ b/SpotifyAPI.Web/Http/APIConnector.cs
@@ -219,13 +219,13 @@ namespace SpotifyAPI.Web.Http
     private async Task ApplyAuthenticator(IRequest request)
     {
 #if NETSTANDARD2_0
-      if (_authenticator != null
-        && !request.Endpoint.IsAbsoluteUri
-        || request.Endpoint.AbsoluteUri.Contains("https://api.spotify.com"))
+      if (_authenticator != null && (
+            !request.Endpoint.IsAbsoluteUri ||
+            request.Endpoint.AbsoluteUri.Contains("https://api.spotify.com")))
 #else
-      if (_authenticator != null
-        && !request.Endpoint.IsAbsoluteUri
-        || request.Endpoint.AbsoluteUri.Contains("https://api.spotify.com", StringComparison.InvariantCulture))
+      if (_authenticator != null && (
+            !request.Endpoint.IsAbsoluteUri ||
+            request.Endpoint.AbsoluteUri.Contains("https://api.spotify.com", StringComparison.InvariantCulture)))
 #endif
       {
         await _authenticator!.Apply(request, this).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- fix null check in APIConnector.ApplyAuthenticator

## Testing
- `dotnet build SpotifyAPI.sln`
- `dotnet test SpotifyAPI.sln` *(fails: missing .NET 3.1/2.2 runtimes)*

------
https://chatgpt.com/codex/tasks/task_e_6851cf5d5698832a834a670861decee5