### PR TITLE
Fix retry newRequest usage and event

### DIFF
--- a/SpotifyAPI.Web/Http/APIConnector.cs
+++ b/SpotifyAPI.Web/Http/APIConnector.cs
@@ -205,10 +205,10 @@ namespace SpotifyAPI.Web.Http
       {
         response = await _retryHandler.HandleRetry(request, response, async (newRequest) =>
         {
-          await ApplyAuthenticator(request).ConfigureAwait(false);
-          var newResponse = await _httpClient.DoRequest(request).ConfigureAwait(false);
+          await ApplyAuthenticator(newRequest).ConfigureAwait(false);
+          var newResponse = await _httpClient.DoRequest(newRequest).ConfigureAwait(false);
           _httpLogger?.OnResponse(newResponse);
-          ResponseReceived?.Invoke(this, response);
+          ResponseReceived?.Invoke(this, newResponse);
           return newResponse;
         }).ConfigureAwait(false);
       }
@@ -219,13 +219,13 @@ namespace SpotifyAPI.Web.Http
     private async Task ApplyAuthenticator(IRequest request)
     {
 #if NETSTANDARD2_0
-      if (_authenticator != null
-        && !request.Endpoint.IsAbsoluteUri
-        || request.Endpoint.AbsoluteUri.Contains("https://api.spotify.com"))
+      if (_authenticator != null && (
+            !request.Endpoint.IsAbsoluteUri ||
+            request.Endpoint.AbsoluteUri.Contains("https://api.spotify.com")))
 #else
-      if (_authenticator != null
-        && !request.Endpoint.IsAbsoluteUri
-        || request.Endpoint.AbsoluteUri.Contains("https://api.spotify.com", StringComparison.InvariantCulture))
+      if (_authenticator != null && (
+            !request.Endpoint.IsAbsoluteUri ||
+            request.Endpoint.AbsoluteUri.Contains("https://api.spotify.com", StringComparison.InvariantCulture)))
 #endif
       {
         await _authenticator!.Apply(request, this).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- fix null check in APIConnector.ApplyAuthenticator
- correct retry callback to use the provided request and emitted response

## Testing
- `dotnet build SpotifyAPI.sln`
- `dotnet test SpotifyAPI.sln` *(fails: missing .NET 3.1/2.2 runtimes)*

------
https://chatgpt.com/codex/tasks/task_e_6851cf5d5698832a834a670861decee5